### PR TITLE
Run integration tests only for master branch but keep copr build for all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/setup-ci
         with:
           copr-user: ${{secrets.COPR_USER}}
-          copr-api-token: ${{secrets.COPR_API_TOKEN}}
+          copr-api-token: ${{secrets.COPR_API_CONFIG}}
 
       - name: Check out sources
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
 
   integration-tests:
     name: DNF Integration Tests
+    # Run integration-tests only for PRs agains master.
+    # We use branches to keep track of older versions + patches that are
+    # present in various releases (rhel, fedora), these get behind master
+    # and no longer work with upstream master ci-dnf-stack.
+    if: github.ref == 'refs/heads/master'
     needs: copr-build
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
Running tests for other branches (branches that maintain older rhel and
fedora versions) agains master branch of CI doesn't make much sense and
is usually broken.

We want to keep running copr builds to make sure the package builds.
The ansible tests are testing more basic functionallity and should still
work for dnf.